### PR TITLE
Don't build libmdbx in debug mode

### DIFF
--- a/mdbx-sys/build.rs
+++ b/mdbx-sys/build.rs
@@ -87,6 +87,7 @@ fn main() {
     cc_builder
         .define("MDBX_BUILD_FLAGS", flags.as_str())
         .define("MDBX_TXN_CHECKOWNER", "0")
+        .define("NDEBUG", "1")
         .file(mdbx.join("mdbx.c"))
         .compile("libmdbx.a");
 }


### PR DESCRIPTION
Debug builds are not supposed to be used in production according to the developers: https://gitflic.ru/project/erthink/libmdbx/issue/7.

Probably fixes #16 as well.