### PR TITLE
Fix linking with musl

### DIFF
--- a/mdbx-sys/build.rs
+++ b/mdbx-sys/build.rs
@@ -94,16 +94,14 @@ fn main() {
             .trim()
     );
 
-    // __cpu_model is not available in musl
-    let is_musl = env::var("TARGET").unwrap().ends_with("-musl");
-
     cc_builder
         .define("MDBX_BUILD_FLAGS", flags.as_str())
-        .define("MDBX_TXN_CHECKOWNER", "0")
-        .define(
-            "MDBX_HAVE_BUILTIN_CPU_SUPPORTS",
-            if is_musl { "0" } else { "1" },
-        )
-        .file(mdbx.join("mdbx.c"))
-        .compile("libmdbx.a");
+        .define("MDBX_TXN_CHECKOWNER", "0");
+
+    // __cpu_model is not available in musl
+    if env::var("TARGET").unwrap().ends_with("-musl") {
+        cc_builder.define("MDBX_HAVE_BUILTIN_CPU_SUPPORTS", "0");
+    }
+
+    cc_builder.file(mdbx.join("mdbx.c")).compile("libmdbx.a");
 }

--- a/mdbx-sys/build.rs
+++ b/mdbx-sys/build.rs
@@ -93,9 +93,17 @@ fn main() {
             .unwrap()
             .trim()
     );
+
+    // __cpu_model is not available in musl
+    let is_musl = env::var("TARGET").unwrap().ends_with("-musl");
+
     cc_builder
         .define("MDBX_BUILD_FLAGS", flags.as_str())
         .define("MDBX_TXN_CHECKOWNER", "0")
+        .define(
+            "MDBX_HAVE_BUILTIN_CPU_SUPPORTS",
+            if is_musl { "0" } else { "1" },
+        )
         .file(mdbx.join("mdbx.c"))
         .compile("libmdbx.a");
 }


### PR DESCRIPTION
Resolves the following ld errors when building with musl (`cargo build --target x86_64-unknown-linux-musl`):

```
mdbx.c:10827: undefined reference to `__cpu_indicator_init'
mdbx.c:10830: undefined reference to `__cpu_model'
mdbx.c:10834: undefined reference to `__cpu_model'
mdbx.c:10838: undefined reference to `__cpu_model'
```