### PR TITLE
fix: `dupsort!` macro import missing qualification

### DIFF
--- a/src/orm/database.rs
+++ b/src/orm/database.rs
@@ -243,7 +243,7 @@ macro_rules! dupsort {
             #[doc = concat!("`DUPSORT` table with seek value type being: [`", stringify!($seek_value), "`].")]
             ( $table_name ) $key [$seek_key] => $value
         );
-        impl DupSort for $table_name {
+        impl $crate::orm::DupSort for $table_name {
             type SeekValue = $seek_value;
         }
     };


### PR DESCRIPTION
When using the `table!` macro, we don't need to import the `Table` trait. This isn't the case for the `dupsort!` macro and the `DupSort` trait, as it doesn't use fully qualified paths. This results in needing to import the `DupSort` trait.