### PR TITLE
fix: update table opening documentation to reference DatabaseOptions

### DIFF
--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -195,7 +195,6 @@ where
     /// The returned table handle may be shared among any transaction in the database.
     ///
     /// The table name may not contain the null character.
-
     pub fn open_table<'txn>(&'txn self, name: Option<&str>) -> Result<Table<'txn>> {
         Table::new(self, name, ffi::MDBX_DB_ACCEDE as c_uint)
     }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -189,11 +189,13 @@ where
     ///
     /// If `name` is not [None], then the returned handle will be for a named table. In this
     /// case the database must be configured to allow named tables through
-    /// [DatabaseBuilder::set_max_tables()](crate::DatabaseBuilder::set_max_tables).
+    /// [DatabaseOptions::max_tables](crate::DatabaseOptions::max_tables) when opening the database
+    /// with [Database::open_with_options](crate::Database::open_with_options).
     ///
     /// The returned table handle may be shared among any transaction in the database.
     ///
     /// The table name may not contain the null character.
+
     pub fn open_table<'txn>(&'txn self, name: Option<&str>) -> Result<Table<'txn>> {
         Table::new(self, name, ffi::MDBX_DB_ACCEDE as c_uint)
     }


### PR DESCRIPTION
Update table opening documentation to reference DatabaseOptions instead of DatabaseBuilder.

The API has changed to use open_with_options with DatabaseOptions, so the documentation
needs to reflect this change. Updated references from DatabaseBuilder::set_max_tables
to DatabaseOptions::max_tables to match the current implementation.